### PR TITLE
Switching to a more precise implementation of request rate module

### DIFF
--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/metrics/LongAdder.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/metrics/LongAdder.java
@@ -158,21 +158,27 @@ public class LongAdder extends Striped64 implements Serializable {
     }
 
     /**
-     * Returns the {@link #sum} as an {@code int} after a narrowing primitive conversion.
+     * Int value of the sum.
+     *
+     * @return Returns the {@link #sum} as an {@code int} after a narrowing primitive conversion.
      */
     public int intValue() {
         return (int) sum();
     }
 
     /**
-     * Returns the {@link #sum} as a {@code float} after a widening primitive conversion.
+     * Float value of the sum.
+     *
+     * @return Returns the {@link #sum} as a {@code float} after a widening primitive conversion.
      */
     public float floatValue() {
         return (float) sum();
     }
 
     /**
-     * Returns the {@link #sum} as a {@code double} after a widening primitive conversion.
+     * Double value of the sum.
+     *
+     * @return Returns the {@link #sum} as a {@code double} after a widening primitive conversion.
      */
     public double doubleValue() {
         return (double) sum();

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/metrics/LongAdder.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/metrics/LongAdder.java
@@ -30,7 +30,7 @@ import java.io.Serializable;
  * @since 1.8
  */
 @SuppressWarnings("all")
-class LongAdder extends Striped64 implements Serializable {
+public class LongAdder extends Striped64 implements Serializable {
     private static final long serialVersionUID = 7249069246863182397L;
 
     /**
@@ -43,7 +43,7 @@ class LongAdder extends Striped64 implements Serializable {
     /**
      * Creates a new adder with initial sum of zero.
      */
-    LongAdder() {
+    public LongAdder() {
     }
 
     /**

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
@@ -44,7 +44,7 @@ public class RequestRateModuleTest {
     }
 
     @Test
-    public void should_report_approximate_request_rate_values() throws ConfigurationException, InterruptedException {
+    public void should_report_exact_request_rate_values() throws ConfigurationException, InterruptedException {
         final CountDownLatch latch = new CountDownLatch(4);
         final LatchTestReporter testReporter = new LatchTestReporter(null, latch);
         final List<Reporter> reporters = new ArrayList<Reporter>() {
@@ -58,7 +58,7 @@ public class RequestRateModuleTest {
         final Query updateQuery = mock(Query.class);
         when(updateQuery.statementType()).thenReturn(Query.StatementType.UPDATE);
         final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
-        for (int i = 1; i < 100; i++) {
+        for (int i = 0; i < 100; i++) {
             module.process(selectQuery);
             module.process(updateQuery);
         }
@@ -68,8 +68,8 @@ public class RequestRateModuleTest {
         module.stop();
 
         assertThat(testReporter.reported).hasSize(4);
-        assertThat(testReporter.reported.get(2).value()).isBetween(80.0, 100.0);
-        assertThat(testReporter.reported.get(3).value()).isBetween(80.0, 100.0);
+        assertThat(testReporter.reported.get(2).value()).isEqualTo(100.0);
+        assertThat(testReporter.reported.get(3).value()).isEqualTo(100.0);
     }
 
     @Test

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
@@ -58,7 +58,7 @@ public class RequestRateModuleTest {
         final Query updateQuery = mock(Query.class);
         when(updateQuery.statementType()).thenReturn(Query.StatementType.UPDATE);
         final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 20; i++) {
             module.process(selectQuery);
             module.process(updateQuery);
         }
@@ -68,8 +68,8 @@ public class RequestRateModuleTest {
         module.stop();
 
         assertThat(testReporter.reported).hasSize(4);
-        assertThat(testReporter.reported.get(2).value()).isEqualTo(100.0);
-        assertThat(testReporter.reported.get(3).value()).isEqualTo(100.0);
+        assertThat(testReporter.reported.get(2).value()).isEqualTo(20.0);
+        assertThat(testReporter.reported.get(3).value()).isEqualTo(20.0);
     }
 
     @Test

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
+import io.smartcat.cassandra.diagnostics.Measurement;
 import io.smartcat.cassandra.diagnostics.Query;
 import io.smartcat.cassandra.diagnostics.config.ConfigurationException;
 import io.smartcat.cassandra.diagnostics.module.LatchTestReporter;
@@ -23,7 +24,7 @@ public class RequestRateModuleTest {
 
     @Test
     public void should_load_default_configuration_and_initialize() throws ConfigurationException {
-        final RequestRateModule module = new RequestRateModule(testConfiguration(), testReporters());
+        final RequestRateModule module = new RequestRateModule(testConfiguration(1), testReporters());
         module.stop();
     }
 
@@ -37,7 +38,7 @@ public class RequestRateModuleTest {
             }
         };
 
-        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
+        final RequestRateModule module = new RequestRateModule(testConfiguration(1), reporters);
         boolean wait = latch.await(100, TimeUnit.MILLISECONDS);
         module.stop();
         assertThat(wait).isTrue();
@@ -45,11 +46,11 @@ public class RequestRateModuleTest {
 
     @Test
     public void should_report_exact_request_rate_values() throws ConfigurationException, InterruptedException {
-        final CountDownLatch latch = new CountDownLatch(4);
-        final LatchTestReporter testReporter = new LatchTestReporter(null, latch);
+        final CountDownLatch latch = new CountDownLatch(20);
+        final LatchTestReporter latchTestReporter = new LatchTestReporter(null, latch);
         final List<Reporter> reporters = new ArrayList<Reporter>() {
             {
-                add(testReporter);
+                add(latchTestReporter);
             }
         };
 
@@ -57,19 +58,31 @@ public class RequestRateModuleTest {
         when(selectQuery.statementType()).thenReturn(Query.StatementType.SELECT);
         final Query updateQuery = mock(Query.class);
         when(updateQuery.statementType()).thenReturn(Query.StatementType.UPDATE);
-        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
-        for (int i = 0; i < 5; i++) {
+        final RequestRateModule module = new RequestRateModule(testConfiguration(1), reporters);
+
+        final long numberOfRequests = 1000;
+        for (int i = 0; i < numberOfRequests / 2; i++) {
             module.process(selectQuery);
             module.process(updateQuery);
         }
-        boolean wait = latch.await(1100, TimeUnit.MILLISECONDS);
 
-        assertThat(wait).isTrue();
+        long requestRate = 0;
+        while (requestRate < numberOfRequests) {
+            requestRate = 0;
+            for (final Measurement measurement : latchTestReporter.reported) {
+                requestRate += measurement.value();
+            }
+            latch.await(1100, TimeUnit.MILLISECONDS);
+        }
+
         module.stop();
 
-        assertThat(testReporter.reported).hasSize(4);
-        assertThat(testReporter.reported.get(2).value()).isEqualTo(5.0);
-        assertThat(testReporter.reported.get(3).value()).isEqualTo(5.0);
+        long totalRequests = 0;
+        for (final Measurement measurement : latchTestReporter.reported) {
+            totalRequests += measurement.value();
+        }
+
+        assertThat(totalRequests).isEqualTo(numberOfRequests);
     }
 
     @Test
@@ -83,17 +96,17 @@ public class RequestRateModuleTest {
             }
         };
 
-        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
+        final RequestRateModule module = new RequestRateModule(testConfiguration(1), reporters);
         boolean wait = latch.await(200, TimeUnit.MILLISECONDS);
         module.stop();
         assertThat(wait).isTrue();
     }
 
-    private ModuleConfiguration testConfiguration() {
+    private ModuleConfiguration testConfiguration(final int period) {
         final ModuleConfiguration configuration = new ModuleConfiguration();
         configuration.measurement = "test_measurement";
         configuration.module = "io.smartcat.cassandra.diagnostics.module.requestrate.RequestRateModule";
-        configuration.options.put("period", 1);
+        configuration.options.put("period", period);
         configuration.options.put("timeunit", "SECONDS");
         return configuration;
     }

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
@@ -23,7 +23,7 @@ public class RequestRateModuleTest {
 
     @Test
     public void should_load_default_configuration_and_initialize() throws ConfigurationException {
-        final RequestRateModule module = new RequestRateModule(testConfiguration(), testReporters());
+        final RequestRateModule module = new RequestRateModule(testConfiguration(1), testReporters());
         module.stop();
     }
 
@@ -37,7 +37,7 @@ public class RequestRateModuleTest {
             }
         };
 
-        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
+        final RequestRateModule module = new RequestRateModule(testConfiguration(1), reporters);
         boolean wait = latch.await(100, TimeUnit.MILLISECONDS);
         module.stop();
         assertThat(wait).isTrue();
@@ -57,19 +57,19 @@ public class RequestRateModuleTest {
         when(selectQuery.statementType()).thenReturn(Query.StatementType.SELECT);
         final Query updateQuery = mock(Query.class);
         when(updateQuery.statementType()).thenReturn(Query.StatementType.UPDATE);
-        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
-        for (int i = 0; i < 20; i++) {
+        final RequestRateModule module = new RequestRateModule(testConfiguration(3), reporters);
+        for (int i = 0; i < 100; i++) {
             module.process(selectQuery);
             module.process(updateQuery);
         }
-        boolean wait = latch.await(1100, TimeUnit.MILLISECONDS);
+        boolean wait = latch.await(3100, TimeUnit.MILLISECONDS);
 
         assertThat(wait).isTrue();
         module.stop();
 
         assertThat(testReporter.reported).hasSize(4);
-        assertThat(testReporter.reported.get(2).value()).isEqualTo(20.0);
-        assertThat(testReporter.reported.get(3).value()).isEqualTo(20.0);
+        assertThat(testReporter.reported.get(2).value()).isEqualTo(100.0);
+        assertThat(testReporter.reported.get(3).value()).isEqualTo(100.0);
     }
 
     @Test
@@ -83,17 +83,17 @@ public class RequestRateModuleTest {
             }
         };
 
-        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
+        final RequestRateModule module = new RequestRateModule(testConfiguration(1), reporters);
         boolean wait = latch.await(200, TimeUnit.MILLISECONDS);
         module.stop();
         assertThat(wait).isTrue();
     }
 
-    private ModuleConfiguration testConfiguration() {
+    private ModuleConfiguration testConfiguration(int period) {
         final ModuleConfiguration configuration = new ModuleConfiguration();
         configuration.measurement = "test_measurement";
         configuration.module = "io.smartcat.cassandra.diagnostics.module.requestrate.RequestRateModule";
-        configuration.options.put("period", 1);
+        configuration.options.put("period", period);
         configuration.options.put("timeunit", "SECONDS");
         return configuration;
     }

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
@@ -23,7 +23,7 @@ public class RequestRateModuleTest {
 
     @Test
     public void should_load_default_configuration_and_initialize() throws ConfigurationException {
-        final RequestRateModule module = new RequestRateModule(testConfiguration(1), testReporters());
+        final RequestRateModule module = new RequestRateModule(testConfiguration(), testReporters());
         module.stop();
     }
 
@@ -37,7 +37,7 @@ public class RequestRateModuleTest {
             }
         };
 
-        final RequestRateModule module = new RequestRateModule(testConfiguration(1), reporters);
+        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
         boolean wait = latch.await(100, TimeUnit.MILLISECONDS);
         module.stop();
         assertThat(wait).isTrue();
@@ -57,19 +57,19 @@ public class RequestRateModuleTest {
         when(selectQuery.statementType()).thenReturn(Query.StatementType.SELECT);
         final Query updateQuery = mock(Query.class);
         when(updateQuery.statementType()).thenReturn(Query.StatementType.UPDATE);
-        final RequestRateModule module = new RequestRateModule(testConfiguration(3), reporters);
-        for (int i = 0; i < 100; i++) {
+        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
+        for (int i = 0; i < 5; i++) {
             module.process(selectQuery);
             module.process(updateQuery);
         }
-        boolean wait = latch.await(3100, TimeUnit.MILLISECONDS);
+        boolean wait = latch.await(1100, TimeUnit.MILLISECONDS);
 
         assertThat(wait).isTrue();
         module.stop();
 
         assertThat(testReporter.reported).hasSize(4);
-        assertThat(testReporter.reported.get(2).value()).isEqualTo(100.0);
-        assertThat(testReporter.reported.get(3).value()).isEqualTo(100.0);
+        assertThat(testReporter.reported.get(2).value()).isEqualTo(5.0);
+        assertThat(testReporter.reported.get(3).value()).isEqualTo(5.0);
     }
 
     @Test
@@ -83,17 +83,17 @@ public class RequestRateModuleTest {
             }
         };
 
-        final RequestRateModule module = new RequestRateModule(testConfiguration(1), reporters);
+        final RequestRateModule module = new RequestRateModule(testConfiguration(), reporters);
         boolean wait = latch.await(200, TimeUnit.MILLISECONDS);
         module.stop();
         assertThat(wait).isTrue();
     }
 
-    private ModuleConfiguration testConfiguration(int period) {
+    private ModuleConfiguration testConfiguration() {
         final ModuleConfiguration configuration = new ModuleConfiguration();
         configuration.measurement = "test_measurement";
         configuration.module = "io.smartcat.cassandra.diagnostics.module.requestrate.RequestRateModule";
-        configuration.options.put("period", period);
+        configuration.options.put("period", 1);
         configuration.options.put("timeunit", "SECONDS");
         return configuration;
     }


### PR DESCRIPTION
Using Meter is not precise as using Longadder counter directly. Switching to this implementation will give us precise request rate measurements.
