### PR TITLE
Metrics measurement name fix and default measurement name in modules

### DIFF
--- a/cassandra-diagnostics-commons/src/main/java/io/smartcat/cassandra/diagnostics/module/ModuleConfiguration.java
+++ b/cassandra-diagnostics-commons/src/main/java/io/smartcat/cassandra/diagnostics/module/ModuleConfiguration.java
@@ -30,6 +30,16 @@ public class ModuleConfiguration {
      */
     public List<String> reporters = new ArrayList<>();
 
+    /**
+     * Get measurement name or default provided value.
+     *
+     * @param defaultMeasurement Default measurement name value
+     * @return measurement name value
+     */
+    public String getMeasurementOrDefault(String defaultMeasurement) {
+        return measurement == null || measurement.isEmpty() ? defaultMeasurement : measurement;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/heartbeat/HeartbeatModule.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/heartbeat/HeartbeatModule.java
@@ -24,6 +24,8 @@ public class HeartbeatModule extends Module {
 
     private static final Logger logger = LoggerFactory.getLogger(HeartbeatModule.class);
 
+    private static final String DEFAULT_MEASUREMENT_NAME = "heartbeat";
+
     private static final String HEARTBEAT_THREAD_NAME = "heartbeat-module";
 
     private final String service;
@@ -41,7 +43,7 @@ public class HeartbeatModule extends Module {
         super(configuration, reporters);
 
         HeartbeatConfiguration config = HeartbeatConfiguration.create(configuration.options);
-        service = configuration.measurement;
+        service = configuration.getMeasurementOrDefault(DEFAULT_MEASUREMENT_NAME);
 
         logger.info("Heartbeat module initialized with {} {} reporting period.", config.period(),
                 config.timeunit().name());

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsCollector.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsCollector.java
@@ -157,7 +157,7 @@ public class MetricsCollector {
         }
 
         for (ObjectInstance objectInstance : mbeanObjectInstances) {
-            MetricsMBean mbean = new MetricsMBean(config.metricsPackageName(), objectInstance,
+            MetricsMBean mbean = new MetricsMBean(config, objectInstance,
                     mbeanServerConn.getMBeanInfo(objectInstance.getObjectName()).getAttributes());
 
             boolean matches = false;

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsConfiguration.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsConfiguration.java
@@ -26,6 +26,7 @@ public class MetricsConfiguration {
         private static final String DEFAULT_JMX_SSL_USERNAME = null;
         private static final String DEFAULT_JMX_SSL_PASSWORD = null;
         private static final String DEFAULT_METRICS_PACKAGE_NAME = "org.apache.cassandra.metrics";
+        private static final String DEFAULT_METRICS_SEPARATOR = "_";
         private static final List<String> DEFAULT_METRICS_PATTERNS = new ArrayList<String>();
 
         /**
@@ -64,14 +65,19 @@ public class MetricsConfiguration {
         public String jmxSslPassword = DEFAULT_JMX_SSL_PASSWORD;
 
         /**
-         * Metrics names list.
-         */
-        public List<String> metricsPatterns = DEFAULT_METRICS_PATTERNS;
-
-        /**
          * Metrics package name.
          */
         public String metricsPackageName = DEFAULT_METRICS_PACKAGE_NAME;
+
+        /**
+         * Metrics measurement name separator.
+         */
+        public String metricsSeparator = DEFAULT_METRICS_SEPARATOR;
+
+        /**
+         * Metrics names list.
+         */
+        public List<String> metricsPatterns = DEFAULT_METRICS_PATTERNS;
     }
 
     private Values values = new Values();
@@ -168,21 +174,30 @@ public class MetricsConfiguration {
     }
 
     /**
-     * Metrics patterns for gathering measurements.
-     *
-     * @return metrics patterns
-     */
-    public List<String> metricsPatterns() {
-        return values.metricsPatterns;
-    }
-
-    /**
      * Metrics package name. Defaults to org.apache.cassandra.metrics:*.
      *
      * @return metrics package name
      */
     public String metricsPackageName() {
         return values.metricsPackageName;
+    }
+
+    /**
+     * Metrics measurement name separator. Defaults to '_' character.
+     *
+     * @return metrics measurement name separator
+     */
+    public String metricsSeparator() {
+        return values.metricsSeparator;
+    }
+
+    /**
+     * Metrics patterns for gathering measurements.
+     *
+     * @return metrics patterns
+     */
+    public List<String> metricsPatterns() {
+        return values.metricsPatterns;
     }
 
 }

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsMBean.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsMBean.java
@@ -10,6 +10,8 @@ public class MetricsMBean {
 
     private final String name;
 
+    private final String separator;
+
     private final ObjectInstance mbean;
 
     private MBeanAttributeInfo[] mbeanAttributes = new MBeanAttributeInfo[0];
@@ -17,13 +19,14 @@ public class MetricsMBean {
     /**
      * Constructor.
      *
-     * @param metricsPackageName metrics package name
-     * @param mbean              mbean object instance
-     * @param mbeanAttributes    mbean attributes
+     * @param config          metrics configuration
+     * @param mbean           mbean object instance
+     * @param mbeanAttributes mbean attributes
      */
-    public MetricsMBean(final String metricsPackageName, final ObjectInstance mbean,
+    public MetricsMBean(final MetricsConfiguration config, final ObjectInstance mbean,
             final MBeanAttributeInfo[] mbeanAttributes) {
-        this.name = getMBeanName(metricsPackageName, mbean);
+        this.name = getMBeanName(config.metricsPackageName(), mbean);
+        this.separator = config.metricsSeparator();
         this.mbean = mbean;
         this.mbeanAttributes = mbeanAttributes;
     }
@@ -78,22 +81,22 @@ public class MetricsMBean {
 
         StringBuilder nameBuilder = new StringBuilder();
         nameBuilder.append(metricsPackageName);
-        nameBuilder.append(".");
+        nameBuilder.append(separator);
         nameBuilder.append(type);
         if (path != null && !path.isEmpty()) {
-            nameBuilder.append(".");
+            nameBuilder.append(separator);
             nameBuilder.append(path);
         }
         if (keyspace != null && !keyspace.isEmpty()) {
-            nameBuilder.append(".");
+            nameBuilder.append(separator);
             nameBuilder.append(keyspace);
         }
         if (scope != null && !scope.isEmpty()) {
-            nameBuilder.append(".");
+            nameBuilder.append(separator);
             nameBuilder.append(scope);
         }
         if (name != null && !name.isEmpty()) {
-            nameBuilder.append(".");
+            nameBuilder.append(separator);
             nameBuilder.append(name);
         }
 

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModule.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModule.java
@@ -25,6 +25,8 @@ public class RequestRateModule extends Module {
 
     private static final Logger logger = LoggerFactory.getLogger(RequestRateModule.class);
 
+    private static final String DEFAULT_MEASUREMENT_NAME = "request_rate";
+
     private static final String REQUEST_RATE_THREAD_NAME = "request-rate-module";
 
     private static final String UPDATE_SUFFIX = "_update";
@@ -61,7 +63,7 @@ public class RequestRateModule extends Module {
         super(configuration, reporters);
 
         RequestRateConfiguration config = RequestRateConfiguration.create(configuration.options);
-        service = configuration.measurement;
+        service = configuration.getMeasurementOrDefault(DEFAULT_MEASUREMENT_NAME);
         period = config.period();
         timeunit = config.timeunit();
         rateFactor = timeunit.toSeconds(1);

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/slowquery/SlowQueryModule.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/slowquery/SlowQueryModule.java
@@ -25,6 +25,8 @@ public class SlowQueryModule extends Module {
 
     private static final Logger logger = LoggerFactory.getLogger(SlowQueryModule.class);
 
+    private static final String DEFAULT_MEASUREMENT_NAME = "slow_query";
+
     private final String hostname;
 
     private final String service;
@@ -41,7 +43,7 @@ public class SlowQueryModule extends Module {
     public SlowQueryModule(ModuleConfiguration configuration, List<Reporter> reporters) throws ConfigurationException {
         super(configuration, reporters);
         hostname = getHostname();
-        service = configuration.measurement;
+        service = configuration.getMeasurementOrDefault(DEFAULT_MEASUREMENT_NAME);
         slowQueryLogDecider = SlowQueryLogDecider.create(SlowQueryConfiguration.create(configuration.options));
     }
 


### PR DESCRIPTION
- Added metrics measurement name separator to configuration (defaults to _)
- Updated modules to use default service name if its not defined
