### PR TITLE
Metrics measurement name fix and switch to currentimemillis

### DIFF
--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/heartbeat/HeartbeatModule.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/heartbeat/HeartbeatModule.java
@@ -1,6 +1,5 @@
 package io.smartcat.cassandra.diagnostics.module.heartbeat;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Timer;
@@ -72,7 +71,7 @@ public class HeartbeatModule extends Module {
 
     private Measurement createMeasurement() {
         Measurement m = Measurement
-                .create(service, 1.0, new Date().getTime(), TimeUnit.MILLISECONDS, new HashMap<String, String>(),
+                .create(service, 1.0, System.currentTimeMillis(), TimeUnit.MILLISECONDS, new HashMap<String, String>(),
                         new HashMap<String, String>());
         return m;
     }

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsCollector.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsCollector.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.rmi.server.RMIClientSocketFactory;
 import java.rmi.server.RMISocketFactory;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -129,7 +128,8 @@ public class MetricsCollector {
                             .getAttribute(mbean.getMBean().getObjectName(), attribute.getName());
 
                     if (value != null) {
-                        measurements.add(createMeasurement(mbean.getMeasurementName() + "." + attribute.getName(),
+                        measurements.add(createMeasurement(
+                                mbean.getMeasurementName() + config.metricsSeparator() + attribute.getName(),
                                 Double.parseDouble(value.toString())));
                     }
 
@@ -143,9 +143,8 @@ public class MetricsCollector {
     }
 
     private Measurement createMeasurement(String service, double value) {
-        return Measurement
-                .create(service, value, new Date().getTime(), TimeUnit.MILLISECONDS, new HashMap<String, String>(),
-                        new HashMap<String, String>());
+        return Measurement.create(service, value, System.currentTimeMillis(), TimeUnit.MILLISECONDS,
+                new HashMap<String, String>(), new HashMap<String, String>());
     }
 
     private Set<MetricsMBean> filterMBeans(final Set<ObjectInstance> mbeanObjectInstances)

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsMBean.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/metrics/MetricsMBean.java
@@ -88,14 +88,15 @@ public class MetricsMBean {
     }
 
     private String nameBuilder(final String metricsPackageName, final ObjectInstance mbean, final String separator) {
-        String type = mbean.getObjectName().getKeyProperty("type");
-        String path = mbean.getObjectName().getKeyProperty("path");
-        String keyspace = mbean.getObjectName().getKeyProperty("keyspace");
-        String scope = mbean.getObjectName().getKeyProperty("scope");
-        String name = mbean.getObjectName().getKeyProperty("name");
+        final String type = mbean.getObjectName().getKeyProperty("type");
+        final String path = mbean.getObjectName().getKeyProperty("path");
+        final String keyspace = mbean.getObjectName().getKeyProperty("keyspace");
+        final String scope = mbean.getObjectName().getKeyProperty("scope");
+        final String name = mbean.getObjectName().getKeyProperty("name");
+        final String packageName = metricsPackageName.replace(".", separator);
 
         StringBuilder nameBuilder = new StringBuilder();
-        nameBuilder.append(metricsPackageName);
+        nameBuilder.append(packageName);
         nameBuilder.append(separator);
         nameBuilder.append(type);
         if (path != null && !path.isEmpty()) {

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModule.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModule.java
@@ -1,6 +1,5 @@
 package io.smartcat.cassandra.diagnostics.module.requestrate;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Timer;
@@ -131,7 +130,7 @@ public class RequestRateModule extends Module {
 
     private Measurement createMeasurement(String service, double rate) {
         return Measurement
-                .create(service, rate, new Date().getTime(), TimeUnit.MILLISECONDS, new HashMap<String, String>(),
+                .create(service, rate, System.currentTimeMillis(), TimeUnit.MILLISECONDS, new HashMap<String, String>(),
                         new HashMap<String, String>());
     }
 }


### PR DESCRIPTION
- Removed `new Date().getTime()` and switched to `System.currentTimeMillis()`
- Added proper metrics measurement name parsing
