### PR TITLE
Add Authorization header checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ httpApiEnabled: true
 httpApiHost: 127.0.0.1
 # specifies the port number for the listening TCP socket. '8998' by default.
 httpApiPort: 8998
+# if API authorization is enabled, API key must be provided through the 'Authorization' header
+httpApiAuthEnabled: false
+# API access key
+httpApiKey: "diagnostics-api-key"
 ```
 
 It implements the following endpoints for mapping HTTP requests to API operations:

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/api/HttpHandler.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/api/HttpHandler.java
@@ -66,7 +66,7 @@ public class HttpHandler extends NanoHTTPD {
     }
 
     private boolean hasValidCredentials(IHTTPSession session) {
-        String header = session.getHeaders().get("Authorization");
+        String header = session.getHeaders().get("authorization");
         return apiKey.equals(header);
     }
 }

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/api/HttpHandler.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/api/HttpHandler.java
@@ -37,15 +37,15 @@ public class HttpHandler extends NanoHTTPD {
      */
     @Override
     public Response serve(IHTTPSession session) {
-        if (apiAuthEnabled) {
-            if (hasValidCredentials(session)) {
-                return respond(session);
-            }
-
-            return newFixedLengthResponse(Status.FORBIDDEN, NanoHTTPD.MIME_PLAINTEXT, "Invalid API key");
+        if (!apiAuthEnabled) {
+            return respond(session);
         }
 
-        return respond(session);
+        if (hasValidCredentials(session)) {
+            return respond(session);
+        }
+
+        return newFixedLengthResponse(Status.FORBIDDEN, NanoHTTPD.MIME_PLAINTEXT, "Invalid API key");
     }
 
     private Response respond(IHTTPSession session) {

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/config/Configuration.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/config/Configuration.java
@@ -69,6 +69,16 @@ public class Configuration {
     public Integer httpApiPort = 8998;
 
     /**
+     * Enables HTTP API key-based authentication.
+     */
+    public Boolean httpApiAuthEnabled = false;
+
+    /**
+     * HTTP API access key.
+     */
+    public String httpApiKey = "diagnostics-api-key";
+
+    /**
      * Reporters configuration list with reporter specific properties.
      */
     public List<ReporterConfiguration> reporters = new ArrayList<>();
@@ -95,5 +105,4 @@ public class Configuration {
         sb.append(" }");
         return sb.toString();
     }
-
 }

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/api/HttpHandlerTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/api/HttpHandlerTest.java
@@ -80,7 +80,7 @@ public class HttpHandlerTest {
         when(session.getMethod()).thenReturn(Method.GET);
 
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", config.httpApiKey);
+        headers.put("authorization", config.httpApiKey);
         when(session.getHeaders()).thenReturn(headers);
         when(session.getUri()).thenReturn("/version");
 
@@ -119,7 +119,7 @@ public class HttpHandlerTest {
         HttpHandler httpApi = new HttpHandler(config, mxBean);
         IHTTPSession session = mock(IHTTPSession.class);
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", "invalid-key");
+        headers.put("authorization", "invalid-key");
         when(session.getHeaders()).thenReturn(headers);
         when(session.getUri()).thenReturn("/version");
         when(session.getMethod()).thenReturn(Method.GET);


### PR DESCRIPTION
By default, API Authorization is disabled. If enabled, all requests are
required to have an 'Authorization' header with valid API key (as
set through the configuration file).