### PR TITLE
Measuring process prepared as well as process unprepared.

### DIFF
--- a/cassandra-diagnostics-connector21/src/main/java/io/smartcat/cassandra/diagnostics/connector/DiagnosticsQueryHandler.java
+++ b/cassandra-diagnostics-connector21/src/main/java/io/smartcat/cassandra/diagnostics/connector/DiagnosticsQueryHandler.java
@@ -96,7 +96,13 @@ public class DiagnosticsQueryHandler implements QueryHandler {
     public ResultMessage processPrepared(CQLStatement statement, QueryState state, QueryOptions options)
             throws RequestExecutionException, RequestValidationException {
         LOGGER.trace("Intercepted processPrepared");
-        return queryProcessor.processPrepared(statement, state, options);
+        final long startTime = System.currentTimeMillis();
+        ResultMessage result = queryProcessor.processPrepared(statement, state, options);
+        final long execTime = System.currentTimeMillis() - startTime;
+
+        queryReporter.report(startTime, execTime, statement, "", state);
+
+        return result;
     }
 
     @Override

--- a/cassandra-diagnostics-connector30/src/main/java/io/smartcat/cassandra/diagnostics/connector/DiagnosticsQueryHandler.java
+++ b/cassandra-diagnostics-connector30/src/main/java/io/smartcat/cassandra/diagnostics/connector/DiagnosticsQueryHandler.java
@@ -80,7 +80,7 @@ public class DiagnosticsQueryHandler implements QueryHandler {
     @Override
     public Prepared prepare(String query, QueryState state, Map<String, ByteBuffer> customPayload)
             throws RequestValidationException {
-        LOGGER.info("Intercepted prepare");
+        LOGGER.trace("Intercepted prepare");
         return queryProcessor.prepare(query, state, customPayload);
     }
 
@@ -100,7 +100,13 @@ public class DiagnosticsQueryHandler implements QueryHandler {
     public ResultMessage processPrepared(CQLStatement statement, QueryState state, QueryOptions options,
             Map<String, ByteBuffer> customPayload) throws RequestExecutionException, RequestValidationException {
         LOGGER.trace("Intercepted processPrepared");
-        return queryProcessor.processPrepared(statement, state, options, customPayload);
+        final long startTime = System.currentTimeMillis();
+        ResultMessage result = queryProcessor.processPrepared(statement, state, options, customPayload);
+        final long execTime = System.currentTimeMillis() - startTime;
+
+        queryReporter.report(startTime, execTime, statement, "", state);
+
+        return result;
     }
 
     @Override


### PR DESCRIPTION
When driver prepares statement it sends only MD5 hash id and server side
finds statement based on that ID. We need to cover both cases, when we have
unprepared string statement and when we have prepared statement.