### PR TITLE
Measurement change

### DIFF
--- a/cassandra-diagnostics-commons/src/main/java/io/smartcat/cassandra/diagnostics/utils/Option.java
+++ b/cassandra-diagnostics-commons/src/main/java/io/smartcat/cassandra/diagnostics/utils/Option.java
@@ -1,0 +1,159 @@
+package io.smartcat.cassandra.diagnostics.utils;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * Option class used for wrapping Java 1.7 API scalar values.
+ *
+ * @param <T> wrapped value type
+ */
+public class Option<T> {
+
+    /**
+     * Empty instance.
+     */
+    private static final Option<?> EMPTY = new Option<>();
+
+    /**
+     * If non-null, the value; if null, indicates no value is present.
+     */
+    public final T value;
+
+    /**
+     * Constructs an empty instance.
+     */
+    private Option() {
+        this.value = null;
+    }
+
+    /**
+     * Returns an empty {@code Option} instance.  No value is present for this
+     * Option.
+     *
+     * @param <T> Type of the non-existent value
+     * @return an empty {@code Option}
+     */
+    public static <T> Option<T> empty() {
+        @SuppressWarnings("unchecked")
+        Option<T> val = (Option<T>) EMPTY;
+        return val;
+    }
+
+    /**
+     * Constructs an instance with the value present.
+     *
+     * @param value the non-null value to be present
+     * @throws NullPointerException if value is null
+     */
+    private Option(T value) {
+        this.value = Objects.requireNonNull(value);
+    }
+
+    /**
+     * Returns an {@code Optional} with the specified present non-null value.
+     *
+     * @param <T>   the class of the value
+     * @param value the value to be present, which must be non-null
+     * @return an {@code Optional} with the value present
+     * @throws NullPointerException if value is null
+     */
+    public static <T> Option<T> of(T value) {
+        return new Option<>(value);
+    }
+
+    /**
+     * Returns an {@code Optional} describing the specified value, if non-null,
+     * otherwise returns an empty {@code Optional}.
+     *
+     * @param <T>   the class of the value
+     * @param value the possibly-null value to describe
+     * @return an {@code Optional} with a present value if the specified value is non-null, otherwise an empty {@code
+     * Optional}
+     */
+    public static <T> Option<T> ofNullable(T value) {
+        return (value == null) ? (Option<T>) empty() : of(value);
+    }
+
+    /**
+     * Returns the value if not empty otherwise throws {@code NoSuchElementException}.
+     *
+     * @return the non-null value
+     * @throws NoSuchElementException if there is no value present
+     * @see Option#hasValue()
+     */
+    public T getValue() {
+        if (value == null) {
+            throw new NoSuchElementException("No value present");
+        }
+        return value;
+    }
+
+    /**
+     * Return {@code true} if there is a value present, otherwise {@code false}.
+     *
+     * @return {@code true} if there is a value present, otherwise {@code false}
+     */
+    public boolean hasValue() {
+        return value != null;
+    }
+
+    /**
+     * Return the value if present, otherwise return {@code defaultValue}.
+     *
+     * @param defaultValue the value to be returned if there is no value present, may be null
+     * @return the value, if present, otherwise {@code defaultValue}
+     */
+    public T getOrDefault(T defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this Option. The
+     * other object is considered equal if:
+     * <ul>
+     * <li>it is also an {@code Option} and;
+     * <li>both instances have no value present or;
+     * <li>the present values are "equal to" each other via {@code equals()}.
+     * </ul>
+     *
+     * @param obj an object to be tested for equality
+     * @return {code true} if the other object is "equal to" this object otherwise {@code false}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof Option)) {
+            return false;
+        }
+
+        Option<?> other = (Option<?>) obj;
+        return Objects.equals(value, other.value);
+    }
+
+    /**
+     * Returns the hash code value of the present value, if any, or 0 (zero) if
+     * no value is present.
+     *
+     * @return hash code value of the present value or 0 if no value is present
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    /**
+     * Returns a non-empty string representation of this Option suitable for
+     * debugging. The exact presentation format is unspecified and may vary
+     * between implementations and versions.
+     *
+     * @return the string representation of this instance
+     */
+    @Override
+    public String toString() {
+        return value != null ? String.format("Option[%s]", value) : "Option.empty";
+    }
+}

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/slowquery/SlowQueryModule.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/slowquery/SlowQueryModule.java
@@ -97,7 +97,7 @@ public class SlowQueryModule extends Module {
         fields.put("statement", query.statement());
 
         final Measurement measurement = Measurement
-                .create(service, query.executionTimeInMilliseconds(), query.startTimeInMilliseconds(),
+                .create(service, (double) query.executionTimeInMilliseconds(), query.startTimeInMilliseconds(),
                         TimeUnit.MILLISECONDS, tags, fields);
 
         logger.trace("Measurement transformed: {}", measurement);

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/status/StatusModule.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/status/StatusModule.java
@@ -134,8 +134,9 @@ public class StatusModule extends Module {
         fields.put("currentlyBlockedTasks", Long.toString(tpStatsInfo.currentlyBlockedTasks));
         fields.put("totalBlockedTasks", Long.toString(tpStatsInfo.totalBlockedTasks));
 
-        return Measurement.create(DEFAULT_TPSTATS_INFO_MEASUREMENT_NAME, null, System.currentTimeMillis(),
-                TimeUnit.MILLISECONDS, tags, fields);
+        return Measurement
+                .create(DEFAULT_TPSTATS_INFO_MEASUREMENT_NAME, null, System.currentTimeMillis(), TimeUnit.MILLISECONDS,
+                        tags, fields);
     }
 
     private Measurement createMeasurement(long repairSessions) {
@@ -144,8 +145,9 @@ public class StatusModule extends Module {
 
         final Map<String, String> fields = new HashMap<>();
 
-        return Measurement.create(DEFAULT_REPAIR_SESSIONS_MEASUREMENT_NAME, repairSessions, System.currentTimeMillis(),
-                TimeUnit.MILLISECONDS, tags, fields);
+        return Measurement
+                .create(DEFAULT_REPAIR_SESSIONS_MEASUREMENT_NAME, (double) repairSessions, System.currentTimeMillis(),
+                        TimeUnit.MILLISECONDS, tags, fields);
     }
 
 }

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/status/StatusModule.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/module/status/StatusModule.java
@@ -118,7 +118,7 @@ public class StatusModule extends Module {
         fields.put("completed", Long.toString(compactionInfo.completed));
         fields.put("completedPercentage", Double.toString(compactionInfo.completedPercentage));
 
-        return Measurement.create(DEFAULT_COMPACTION_INFO_MEASUREMENT_NAME, 0, System.currentTimeMillis(),
+        return Measurement.create(DEFAULT_COMPACTION_INFO_MEASUREMENT_NAME, null, System.currentTimeMillis(),
                 TimeUnit.MILLISECONDS, tags, fields);
     }
 
@@ -134,7 +134,7 @@ public class StatusModule extends Module {
         fields.put("currentlyBlockedTasks", Long.toString(tpStatsInfo.currentlyBlockedTasks));
         fields.put("totalBlockedTasks", Long.toString(tpStatsInfo.totalBlockedTasks));
 
-        return Measurement.create(DEFAULT_TPSTATS_INFO_MEASUREMENT_NAME, 0, System.currentTimeMillis(),
+        return Measurement.create(DEFAULT_TPSTATS_INFO_MEASUREMENT_NAME, null, System.currentTimeMillis(),
                 TimeUnit.MILLISECONDS, tags, fields);
     }
 

--- a/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/reporter/LogReporter.java
+++ b/cassandra-diagnostics-core/src/main/java/io/smartcat/cassandra/diagnostics/reporter/LogReporter.java
@@ -32,7 +32,7 @@ public class LogReporter extends Reporter {
 
     @Override
     public void report(Measurement measurement) {
-        logger.info(LOG_TEMPLATE, measurement.name().toUpperCase(), measurement.time(), measurement.value(),
+        logger.info(LOG_TEMPLATE, measurement.name().toUpperCase(), measurement.time(), measurement.getValue(),
                 measurement.tags().toString(), measurement.fields().toString());
     }
 

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/requestrate/RequestRateModuleTest.java
@@ -71,7 +71,7 @@ public class RequestRateModuleTest {
         while (requestRate < numberOfRequests) {
             requestRate = 0;
             for (final Measurement measurement : latchTestReporter.getReported()) {
-                requestRate += measurement.value();
+                requestRate += measurement.getValue();
             }
             latch.await(1100, TimeUnit.MILLISECONDS);
         }
@@ -80,7 +80,7 @@ public class RequestRateModuleTest {
 
         long totalRequests = 0;
         for (final Measurement measurement : latchTestReporter.getReported()) {
-            totalRequests += measurement.value();
+            totalRequests += measurement.getValue();
         }
 
         assertThat(totalRequests).isEqualTo(numberOfRequests);
@@ -127,7 +127,7 @@ public class RequestRateModuleTest {
         while (requestRate < numberOfRequests / 2) {
             requestRate = 0;
             for (final Measurement measurement : latchTestReporter.getReported()) {
-                requestRate += measurement.value();
+                requestRate += measurement.getValue();
             }
             latch.await(1100, TimeUnit.MILLISECONDS);
         }
@@ -136,7 +136,7 @@ public class RequestRateModuleTest {
 
         double totalRequests = 0;
         for (final Measurement measurement : latchTestReporter.getReported()) {
-            totalRequests += measurement.value();
+            totalRequests += measurement.getValue();
         }
 
         assertThat(totalRequests).isEqualTo(numberOfRequests / 2);

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/slowquery/SlowQueryModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/slowquery/SlowQueryModuleTest.java
@@ -43,7 +43,8 @@ public class SlowQueryModuleTest {
         assertThat(measurement.fields().keySet()).isEqualTo(Sets.newSet("statement", "client"));
         assertThat(measurement.fields().get("statement")).isEqualTo("select count(*) from keyspace.table");
         assertThat(measurement.fields().get("client")).isEqualTo("/127.0.0.1:40042");
-        assertThat(measurement.value()).isEqualTo(234);
+        assertThat(measurement.hasValue()).isTrue();
+        assertThat(measurement.getValue()).isEqualTo(234);
 
         assertThat(measurement.tags().keySet()).isEqualTo(Sets.newSet("host", "statementType"));
         assertThat(measurement.tags().get("statementType")).isEqualTo("SELECT");
@@ -88,7 +89,7 @@ public class SlowQueryModuleTest {
         long slowQueryCounts = 0;
         for (final Measurement measurement : latchTestReporter.getReported()) {
             if (measurement.name().equals(SLOW_QUERY_MESUREMENT_NAME + SLOW_QUERY_COUNT_SUFIX)) {
-                slowQueryCounts += measurement.value();
+                slowQueryCounts += measurement.getValue();
             }
         }
 

--- a/cassandra-diagnostics-reporter-datadog/src/test/java/io/smartcat/diagnostics/reporter/DatadogReporterTest.java
+++ b/cassandra-diagnostics-reporter-datadog/src/test/java/io/smartcat/diagnostics/reporter/DatadogReporterTest.java
@@ -61,7 +61,7 @@ public class DatadogReporterTest {
 
     @Test
     public void should_send_measurement() throws SocketException, InterruptedException, UnknownHostException {
-        final TestUDPServer testUDPServer = new TestUDPServer();
+        final TestUDPServer testUDPServer = new TestUDPServer(1);
         Thread runner = new Thread(testUDPServer);
         runner.start();
 
@@ -79,16 +79,62 @@ public class DatadogReporterTest {
         Map<String, String> fields = new HashMap<>();
         fields.put("v2", "abc");
 
-        final Measurement measurement = Measurement.create("test-metric", 909.0, System.currentTimeMillis(),
-                TimeUnit.MILLISECONDS, tags, fields);
+        final Measurement measurement = Measurement
+                .create("test-metric", 909.0, System.currentTimeMillis(), TimeUnit.MILLISECONDS, tags, fields);
 
         reporter.report(measurement);
 
-        runner.join();
+        runner.join(500);
 
         assertThat(testUDPServer.receivedMessages.size()).isEqualTo(1);
         assertThat(testUDPServer.receivedMessages.get(0))
                 .contains("test-metric:909|g|#host:somehost,tag2:two,tag3:three,tag2:tv2,tag1:tv1");
+
+        testUDPServer.stop();
+    }
+
+    @Test
+    public void should_send_measurement_for_each_field_in_complex_measurement()
+            throws SocketException, InterruptedException, UnknownHostException {
+        final TestUDPServer testUDPServer = new TestUDPServer(4);
+        Thread runner = new Thread(testUDPServer);
+        runner.start();
+
+        final ReporterConfiguration config = new ReporterConfiguration();
+        config.options.put("statsDHost", "localhost");
+        config.options.put("statsDPort", 9876);
+        config.options.put("keysPrefix", "prefix");
+        config.options.put("fixedTags", Arrays.asList("host:somehost,tag2:two,tag3:three"));
+        final DatadogReporter reporter = new DatadogReporter(config);
+
+        Map<String, String> tags = new HashMap<>();
+        tags.put("tag1", "tv1");
+        tags.put("tag2", "tv2");
+
+        Map<String, String> fields = new HashMap<>();
+        fields.put("v1", "15.0");
+        fields.put("v2", "26.0");
+        fields.put("v3", "50.0");
+        fields.put("v4", "1234.0");
+
+        final Measurement measurement = Measurement
+                .create("test-metric", null, System.currentTimeMillis(), TimeUnit.MILLISECONDS, tags, fields);
+
+        reporter.report(measurement);
+        runner.join(500);
+
+        assertThat(testUDPServer.receivedMessages.size()).isEqualTo(4);
+
+        assertThat(testUDPServer.receivedMessages.get(0))
+                .isEqualTo("prefix.test-metric.v1:15|g|#host:somehost,tag2:two,tag3:three,tag2:tv2,tag1:tv1");
+        assertThat(testUDPServer.receivedMessages.get(1))
+                .isEqualTo("prefix.test-metric.v2:26|g|#host:somehost,tag2:two,tag3:three,tag2:tv2,tag1:tv1");
+        assertThat(testUDPServer.receivedMessages.get(2))
+                .isEqualTo("prefix.test-metric.v3:50|g|#host:somehost,tag2:two,tag3:three,tag2:tv2,tag1:tv1");
+        assertThat(testUDPServer.receivedMessages.get(3))
+                .isEqualTo("prefix.test-metric.v4:1234|g|#host:somehost,tag2:two,tag3:three,tag2:tv2,tag1:tv1");
+
+        testUDPServer.stop();
     }
 
     private class TestUDPServer implements Runnable {
@@ -97,22 +143,36 @@ public class DatadogReporterTest {
 
         private byte[] receiveData = new byte[1024];
 
-        private TestUDPServer() throws SocketException, UnknownHostException {
+        private DatagramPacket receivePacket = new DatagramPacket(receiveData, receiveData.length);
 
+        private final int expectedMessages;
+
+        private TestUDPServer(int expectedMessages) throws SocketException, UnknownHostException {
+            this.expectedMessages = expectedMessages;
         }
 
         public List<String> receivedMessages = new ArrayList<>();
 
         public void run() {
             try {
-                DatagramPacket receivePacket = new DatagramPacket(receiveData, receiveData.length);
-                serverSocket.receive(receivePacket);
-                String message = new String(receivePacket.getData());
-
-                receivedMessages.add(message);
+                while (true) {
+                    serverSocket.receive(receivePacket);
+                    String[] messages = new String(receivePacket.getData()).split("\n");
+                    for (String message : messages) {
+                        receivedMessages.add(message.trim());
+                    }
+                    if (receivedMessages.size() == this.expectedMessages) {
+                        break;
+                    }
+                }
             } catch (IOException e) {
                 assert false;
             }
+        }
+
+        public void stop() {
+            serverSocket.close();
+            serverSocket = null;
         }
     }
 

--- a/cassandra-diagnostics-reporter-datadog/src/test/java/io/smartcat/diagnostics/reporter/DatadogReporterTest.java
+++ b/cassandra-diagnostics-reporter-datadog/src/test/java/io/smartcat/diagnostics/reporter/DatadogReporterTest.java
@@ -79,7 +79,7 @@ public class DatadogReporterTest {
         Map<String, String> fields = new HashMap<>();
         fields.put("v2", "abc");
 
-        final Measurement measurement = Measurement.create("test-metric", 909, System.currentTimeMillis(),
+        final Measurement measurement = Measurement.create("test-metric", 909.0, System.currentTimeMillis(),
                 TimeUnit.MILLISECONDS, tags, fields);
 
         reporter.report(measurement);

--- a/cassandra-diagnostics-reporter-influx/src/main/java/io/smartcat/cassandra/diagnostics/reporter/InfluxReporter.java
+++ b/cassandra-diagnostics-reporter-influx/src/main/java/io/smartcat/cassandra/diagnostics/reporter/InfluxReporter.java
@@ -89,8 +89,8 @@ public class InfluxReporter extends Reporter {
         influx.createDatabase(dbName);
 
         final int pointsInBatch = configuration.getDefaultOption(POINTS_IN_BATCH_PROP, DEFAULT_POINTS_IN_BATCH);
-        final int flushPeriodInSeconds = configuration.getDefaultOption(FLUSH_PERIOD_IN_SECONDS_PROP,
-                DEFAULT_FLUSH_PERIOD_IN_SECONDS);
+        final int flushPeriodInSeconds = configuration
+                .getDefaultOption(FLUSH_PERIOD_IN_SECONDS_PROP, DEFAULT_FLUSH_PERIOD_IN_SECONDS);
 
         influx.enableBatch(pointsInBatch, flushPeriodInSeconds, TimeUnit.SECONDS);
     }
@@ -112,7 +112,9 @@ public class InfluxReporter extends Reporter {
             for (Map.Entry<String, String> field : measurement.fields().entrySet()) {
                 builder.addField(field.getKey(), field.getValue());
             }
-            builder.addField("value", measurement.value());
+            if (measurement.hasValue()) {
+                builder.addField("value", measurement.getValue());
+            }
 
             influx.write(dbName, retentionPolicy, builder.build());
         } catch (Exception e) {

--- a/cassandra-diagnostics-reporter-riemann/src/main/java/io/smartcat/cassandra/diagnostics/reporter/RiemannReporter.java
+++ b/cassandra-diagnostics-reporter-riemann/src/main/java/io/smartcat/cassandra/diagnostics/reporter/RiemannReporter.java
@@ -78,13 +78,13 @@ public class RiemannReporter extends Reporter {
                 riemannClient.reconnect();
             } catch (IOException e) {
                 logger.warn("Cannot reconnect, skipping measurement {} with value {}.", measurement.name(),
-                        measurement.value());
+                        measurement.getOrDefault(0d));
                 return;
             }
         }
 
-        logger.debug("Sending Measurement: name={}, value={}, time={}", measurement.name(), measurement.value(),
-                measurement.time());
+        logger.debug("Sending Measurement: name={}, value={}, time={}", measurement.name(),
+                measurement.getOrDefault(0d), measurement.time());
         try {
             sendEvent(measurement);
         } catch (Exception e) {
@@ -103,7 +103,9 @@ public class RiemannReporter extends Reporter {
         final EventDSL event = riemannClient.event();
         event.service(measurement.name());
         event.state("ok");
-        event.metric(measurement.value());
+        if (measurement.hasValue()) {
+            event.metric(measurement.getValue());
+        }
         event.time(measurement.time());
         event.ttl(30);
         for (Map.Entry<String, String> tag : measurement.tags().entrySet()) {

--- a/cassandra-diagnostics-reporter-telegraf/src/test/java/io/smartcat/cassandra/diagnostics/reporter/TelegrafReporterTest.java
+++ b/cassandra-diagnostics-reporter-telegraf/src/test/java/io/smartcat/cassandra/diagnostics/reporter/TelegrafReporterTest.java
@@ -2,7 +2,10 @@ package io.smartcat.cassandra.diagnostics.reporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;


### PR DESCRIPTION
Switched to using Option for measurement value. This helps stone-age platforms (as datadog) save each measurement field as a single measurement instead of having it all in one (as influx for example).