### PR TITLE
Fixes #244 - adding compaction settings info.

### DIFF
--- a/cassandra-diagnostics-commons/src/main/java/io/smartcat/cassandra/diagnostics/info/CompactionSettingsInfo.java
+++ b/cassandra-diagnostics-commons/src/main/java/io/smartcat/cassandra/diagnostics/info/CompactionSettingsInfo.java
@@ -1,0 +1,51 @@
+package io.smartcat.cassandra.diagnostics.info;
+
+/**
+ * Info about all compactions on node.
+ */
+public class CompactionSettingsInfo {
+
+    /**
+     * Compaction throughput.
+     */
+    public final int compactionThroughput;
+
+    /**
+     * Core compactor threads.
+     */
+    public final int coreCompactorThreads;
+
+    /**
+     * Maximum compactor threads.
+     */
+    public final int maximumCompactorThreads;
+
+    /**
+     * Core validator threads.
+     */
+    public final int coreValidatorThreads;
+
+    /**
+     * Maximum validator threads.
+     */
+    public final int maximumValidatorThreads;
+
+    /**
+     * Compaction class constructor.
+     *
+     * @param compactionThroughput      compaction throughput
+     * @param coreCompactorThreads      core compactor threads
+     * @param maximumCompactorThreads   maximum compactor threads
+     * @param coreValidatorThreads core validator threads
+     * @param maximumValidatorThreads   maximum validator threads
+     */
+    public CompactionSettingsInfo(int compactionThroughput, int coreCompactorThreads, int maximumCompactorThreads,
+            int coreValidatorThreads, int maximumValidatorThreads) {
+        this.compactionThroughput = compactionThroughput;
+        this.coreCompactorThreads = coreCompactorThreads;
+        this.maximumCompactorThreads = maximumCompactorThreads;
+        this.coreValidatorThreads = coreValidatorThreads;
+        this.maximumValidatorThreads = maximumValidatorThreads;
+    }
+
+}

--- a/cassandra-diagnostics-commons/src/main/java/io/smartcat/cassandra/diagnostics/info/InfoProvider.java
+++ b/cassandra-diagnostics-commons/src/main/java/io/smartcat/cassandra/diagnostics/info/InfoProvider.java
@@ -29,6 +29,13 @@ public interface InfoProvider {
     long getRepairSessions();
 
     /**
+     * Get compaction settings info for specific node.
+     *
+     * @return compaction settings info
+     */
+    CompactionSettingsInfo getCompactionSettingsInfo();
+
+    /**
      * Get the list of unreachable nodes.
      * @return unreachable nodes list
      */

--- a/cassandra-diagnostics-connector21/src/main/java/io/smartcat/cassandra/diagnostics/connector/NodeProbeWrapper.java
+++ b/cassandra-diagnostics-connector21/src/main/java/io/smartcat/cassandra/diagnostics/connector/NodeProbeWrapper.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.smartcat.cassandra.diagnostics.info.CompactionInfo;
+import io.smartcat.cassandra.diagnostics.info.CompactionSettingsInfo;
 import io.smartcat.cassandra.diagnostics.info.InfoProvider;
 import io.smartcat.cassandra.diagnostics.info.TPStatsInfo;
 
@@ -114,5 +115,19 @@ public class NodeProbeWrapper implements InfoProvider {
     public List<String> getUnreachableNodes() {
         List<String> unreachableNodes = this.nodeProbe.getUnreachableNodes();
         return unreachableNodes;
+    }
+
+    /**
+     * Get compaction settings info for.
+     *
+     * @return compaction settings info.
+     */
+    @Override
+    public CompactionSettingsInfo getCompactionSettingsInfo() {
+        return new CompactionSettingsInfo(nodeProbe.getCompactionThroughput(),
+                nodeProbe.getCompactionManagerProxy().getCoreCompactorThreads(),
+                nodeProbe.getCompactionManagerProxy().getMaximumCompactorThreads(),
+                nodeProbe.getCompactionManagerProxy().getCoreValidationThreads(),
+                nodeProbe.getCompactionManagerProxy().getMaximumValidatorThreads());
     }
 }

--- a/cassandra-diagnostics-connector30/src/main/java/io/smartcat/cassandra/diagnostics/connector/NodeProbeWrapper.java
+++ b/cassandra-diagnostics-connector30/src/main/java/io/smartcat/cassandra/diagnostics/connector/NodeProbeWrapper.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Multimap;
 
 import io.smartcat.cassandra.diagnostics.info.CompactionInfo;
+import io.smartcat.cassandra.diagnostics.info.CompactionSettingsInfo;
 import io.smartcat.cassandra.diagnostics.info.InfoProvider;
 import io.smartcat.cassandra.diagnostics.info.TPStatsInfo;
 
@@ -116,6 +117,20 @@ public class NodeProbeWrapper implements InfoProvider {
     public List<String> getUnreachableNodes() {
         List<String> unreachableNodes = this.nodeProbe.getUnreachableNodes();
         return unreachableNodes;
+    }
+
+    /**
+     * Get compaction settings info for.
+     *
+     * @return compaction settings info.
+     */
+    @Override
+    public CompactionSettingsInfo getCompactionSettingsInfo() {
+        return new CompactionSettingsInfo(nodeProbe.getCompactionThroughput(),
+                nodeProbe.getCompactionManagerProxy().getCoreCompactorThreads(),
+                nodeProbe.getCompactionManagerProxy().getMaximumCompactorThreads(),
+                nodeProbe.getCompactionManagerProxy().getCoreValidationThreads(),
+                nodeProbe.getCompactionManagerProxy().getMaximumValidatorThreads());
     }
 
 }

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/status/StatusModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/status/StatusModuleTest.java
@@ -19,6 +19,7 @@ import io.smartcat.cassandra.diagnostics.DiagnosticsAgent;
 import io.smartcat.cassandra.diagnostics.GlobalConfiguration;
 import io.smartcat.cassandra.diagnostics.config.ConfigurationException;
 import io.smartcat.cassandra.diagnostics.info.CompactionInfo;
+import io.smartcat.cassandra.diagnostics.info.CompactionSettingsInfo;
 import io.smartcat.cassandra.diagnostics.info.InfoProvider;
 import io.smartcat.cassandra.diagnostics.info.TPStatsInfo;
 import io.smartcat.cassandra.diagnostics.module.LatchTestReporter;
@@ -37,6 +38,7 @@ public class StatusModuleTest {
     public void should_load_default_configuration_and_initialize() throws ConfigurationException {
         InfoProvider infoProvider = mock(InfoProvider.class);
         when(infoProvider.getCompactions()).thenReturn(new ArrayList<CompactionInfo>());
+        when(infoProvider.getCompactionSettingsInfo()).thenReturn(getCompactionSettingsInfo());
         PowerMockito.mockStatic(DiagnosticsAgent.class);
         PowerMockito.when(DiagnosticsAgent.getInfoProvider()).thenReturn(infoProvider);
 
@@ -51,6 +53,7 @@ public class StatusModuleTest {
     public void should_report_compaction_info_when_started() throws ConfigurationException, InterruptedException {
         InfoProvider infoProvider = mock(InfoProvider.class);
         when(infoProvider.getCompactions()).thenReturn(getCompactions());
+        when(infoProvider.getCompactionSettingsInfo()).thenReturn(getCompactionSettingsInfo());
         PowerMockito.mockStatic(DiagnosticsAgent.class);
         PowerMockito.when(DiagnosticsAgent.getInfoProvider()).thenReturn(infoProvider);
 
@@ -67,7 +70,7 @@ public class StatusModuleTest {
         boolean wait = latch.await(1000, TimeUnit.MILLISECONDS);
         module.stop();
         assertThat(wait).isTrue();
-        assertThat(testReporter.getReported().size()).isEqualTo(1);
+        assertThat(testReporter.getReported().size()).isEqualTo(2);
     }
 
     @Test
@@ -168,6 +171,10 @@ public class StatusModuleTest {
                 add(compactionInfo);
             }
         };
+    }
+
+    private CompactionSettingsInfo getCompactionSettingsInfo() {
+        return new CompactionSettingsInfo(16, 1, 1, 1, 1);
     }
 
     private List<TPStatsInfo> getTPStats() {

--- a/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/status/StatusModuleTest.java
+++ b/cassandra-diagnostics-core/src/test/java/io/smartcat/cassandra/diagnostics/module/status/StatusModuleTest.java
@@ -57,7 +57,7 @@ public class StatusModuleTest {
         PowerMockito.mockStatic(DiagnosticsAgent.class);
         PowerMockito.when(DiagnosticsAgent.getInfoProvider()).thenReturn(infoProvider);
 
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(2);
         final LatchTestReporter testReporter = new LatchTestReporter(null, GlobalConfiguration.getDefault(), latch);
         final List<Reporter> reporters = new ArrayList<Reporter>() {
             {

--- a/cassandra-diagnostics-ft/src/functional-test/java/io/smartcat/cassandra/diagnostics/ft/basic/FTBasic.java
+++ b/cassandra-diagnostics-ft/src/functional-test/java/io/smartcat/cassandra/diagnostics/ft/basic/FTBasic.java
@@ -81,7 +81,7 @@ public class FTBasic {
         boolean heartbeatFound = false;
         boolean requestRateFound = false;
         boolean repairSessionsFound = false;
-        boolean compactionInfoFound = false;
+        boolean compactionSettingsInfoFound = false;
         boolean numberOfUnreachableNodesFound = false;
         while ((line = reader.readLine()) != null) {
             if (line.matches(".* QUERYREPORT_COUNT.*")) {
@@ -104,8 +104,8 @@ public class FTBasic {
                 repairSessionsFound = true;
                 continue;
             }
-            if (line.matches(".* COMPACTION_INFO.*")) {
-                compactionInfoFound = true;
+            if (line.matches(".* COMPACTION_SETTINGS_INFO.*")) {
+                compactionSettingsInfoFound = true;
                 continue;
             }
             if (line.matches(".* NUMBER_OF_UNREACHABLE_NODES.*")) {
@@ -120,7 +120,7 @@ public class FTBasic {
         Assertions.assertThat(heartbeatFound).isTrue();
         Assertions.assertThat(requestRateFound).isTrue();
         Assertions.assertThat(repairSessionsFound).isTrue();
-        // TODO: fix compaction info for 2.1 Assertions.assertThat(compactionInfoFound).isTrue();
+        Assertions.assertThat(compactionSettingsInfoFound).isTrue();
         Assertions.assertThat(numberOfUnreachableNodesFound).isTrue();
     }
 


### PR DESCRIPTION
We sent compaction info when there are compactions running. This is fine
from perspective of single and ongoing compactions. But we are configuring
whole status module to have period and on that period it should send some
measurement (health of cluster, unreacgable nodes, state of threads).

I have added compaction settings which are sent on configurable time period
always and single compaction info is sent per compaction when there are
running of compactions.